### PR TITLE
Use json parser over query parser

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -16,7 +16,7 @@ module OmniAuth
       }
 
       option :token_params, {
-        :parse => :query
+        :parse => :json
       }
 
       option :access_token_options, {


### PR DESCRIPTION
This version of the omniauth-facebook gem uses the non-versioned facebook graph API, which means that it's behaviour can change has versions are deprecated (facebook defaults it to the earliest non-deprecated version of the API). Currently, this non-versioned API returns json, where it used to return access tokens in the query string format.

I've forked the repo for our use as it is currently on 4.x, and we're using 1.5.1 in central auth. This avoids us bumping three major versions, and keeps the changes as minimal as possible, keeping in mind that central auth is slated to be deprecated anyway.